### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -9,6 +9,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
 

--- a/.github/workflows/supabase-db-push.yml
+++ b/.github/workflows/supabase-db-push.yml
@@ -1,5 +1,8 @@
 name: Supabase DB Push
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/gameingame-eng/ProgCheck-website/security/code-scanning/2](https://github.com/gameingame-eng/ProgCheck-website/security/code-scanning/2)

Add an explicit `permissions` block to the workflow to enforce least privilege for `GITHUB_TOKEN`.  
Best fix here: define workflow-level permissions with only `contents: read`, since the shown job only needs repository read access for `actions/checkout@v4` and does not perform write operations to GitHub resources.

Change file: `.github/workflows/supabase-db-push.yml`  
Region: after `name` (or before `jobs`) at workflow root.

No imports, methods, or dependencies are needed—just YAML configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
